### PR TITLE
fix: match strapi port at docker binding

### DIFF
--- a/.devcontainer/docker-compose.yaml
+++ b/.devcontainer/docker-compose.yaml
@@ -30,7 +30,7 @@ services:
         target: /app
     ports:
       # Expose strapi to port 8001
-      - "8001:1337"
+      - "8001:8001"
     depends_on:
       - strapi-postgres
 

--- a/strapi/.devcontainer/Dockerfile
+++ b/strapi/.devcontainer/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /app
 USER node
 
 # expose strapi port
-EXPOSE 1337
+EXPOSE 8001
 
 # install dependencies and run in watch mode
 CMD npm install && npm run env:check && npm run develop

--- a/strapi/.env-check.dev.ts
+++ b/strapi/.env-check.dev.ts
@@ -84,7 +84,7 @@ const joi = Joi.extend((joi) => ({
 const schema = joi
   .object({
     HOST: joi.string().ip({ version: "ipv4" }).default("0.0.0.0"),
-    PORT: joi.number().greater(1024).default(1337),
+    PORT: joi.number().greater(1024).default(8001),
     APP_KEYS: joi
       .stringArray()
       .items(joi.string().base64())

--- a/strapi/.env.example
+++ b/strapi/.env.example
@@ -1,5 +1,5 @@
 HOST=0.0.0.0
-PORT=1337
+PORT=8001
 APP_KEYS="toBeModified1,toBeModified2"
 API_TOKEN_SALT=tobemodified
 ADMIN_JWT_SECRET=tobemodified

--- a/strapi/config/server.ts
+++ b/strapi/config/server.ts
@@ -1,6 +1,6 @@
 export default ({ env }) => ({
   host: env('HOST', '0.0.0.0'),
-  port: env.int('PORT', 1337),
+  port: env.int('PORT', 8001),
   app: {
     keys: env.array('APP_KEYS'),
   },


### PR DESCRIPTION
Closes #19 

This PR fixes a bug where strapi is unresponsive if the port bind in docker does not match in the container and the local binding.