### PR TITLE
fix: fix mail links

### DIFF
--- a/app/src/components/Footer.tsx
+++ b/app/src/components/Footer.tsx
@@ -28,7 +28,7 @@ export default function Footer(props: {
           />
           <p className={styles.coord}>
             {props.association.address} <br />
-            <a href="mailto:{association.email}">
+            <a href={`mailto:${props.association.email}`}>
               {props.association.email}
             </a>{" "}
             <br />

--- a/app/src/components/Footer.tsx
+++ b/app/src/components/Footer.tsx
@@ -30,7 +30,7 @@ export default function Footer(props: {
             {props.association.address} <br />
             <a href={`mailto:${props.association.email}`}>
               {props.association.email}
-            </a>{" "}
+            </a>
             <br />
             {props.association.phone}
           </p>

--- a/app/src/components/SocialsList.tsx
+++ b/app/src/components/SocialsList.tsx
@@ -14,20 +14,38 @@ export default function SocialsList(props: {
   return (
     <div className={styles.socialsList}>
       <div className={styles.list}>
-        {props.socials.map((s) => (
-          <Link
-            href={s.link || ""}
-            id={s.id?.toString()}
-            key={s.id?.toString()}
-          >
+        {props.socials.map((s) => {
+          const content = (
             <DirectusImage
               sizes="4rem"
               img={s.logo}
               name={s.media_name}
               className={`${styles.social} ${props.light ? styles.light : ""}`}
             />
-          </Link>
-        ))}
+          );
+
+          if (/^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$/.test(s.link || "")) {
+            return (
+              <a
+                href={`mailto:${s.link}`}
+                id={s.id?.toString()}
+                key={s.id?.toString()}
+              >
+                {content}
+              </a>
+            );
+          } else {
+            return (
+              <Link
+                href={s.link || ""}
+                id={s.id?.toString()}
+                key={s.id?.toString()}
+              >
+                {content}
+              </Link>
+            );
+          }
+        })}
       </div>
     </div>
   );


### PR DESCRIPTION
Fixed the mail link in `SocialsList` components. Uses a regex to distinguish emails from regular links and adapts the link accordingly.

I also fixed the email in the footer, since the link was not correctly interpolated.

Closes #49.