### PR TITLE
feat: add fully setup directus snapshot

### DIFF
--- a/directus/snapshot.yaml
+++ b/directus/snapshot.yaml
@@ -14,10 +14,10 @@ collections:
       display_template: null
       group: null
       hidden: false
-      icon: null
+      icon: groups_2
       item_duplication_fields: null
       note: null
-      preview_url: null
+      preview_url: https://clic.epfl.ch/fr-FR/association
       singleton: true
       sort: 1
       sort_field: null
@@ -32,18 +32,18 @@ collections:
       archive_app_filter: true
       archive_field: null
       archive_value: null
-      collapse: open
+      collapse: closed
       collection: association_memberships
       color: null
       display_template: null
       group: association
       hidden: false
-      icon: null
+      icon: emoji_people
       item_duplication_fields: null
       note: null
       preview_url: null
       singleton: false
-      sort: 4
+      sort: 2
       sort_field: null
       translations: null
       unarchive_value: null
@@ -91,37 +91,13 @@ collections:
       note: null
       preview_url: null
       singleton: false
-      sort: 5
+      sort: 4
       sort_field: null
       translations: null
       unarchive_value: null
       versioning: false
     schema:
       name: association_partners
-  - collection: association_pole_translations
-    meta:
-      accountability: all
-      archive_app_filter: true
-      archive_field: null
-      archive_value: null
-      collapse: open
-      collection: association_pole_translations
-      color: null
-      display_template: null
-      group: null
-      hidden: true
-      icon: import_export
-      item_duplication_fields: null
-      note: null
-      preview_url: null
-      singleton: false
-      sort: 1
-      sort_field: null
-      translations: null
-      unarchive_value: null
-      versioning: false
-    schema:
-      name: association_pole_translations
   - collection: association_poles
     meta:
       accountability: all
@@ -132,14 +108,14 @@ collections:
       collection: association_poles
       color: null
       display_template: null
-      group: null
+      group: association
       hidden: false
-      icon: null
+      icon: workspaces
       item_duplication_fields: null
       note: null
-      preview_url: null
+      preview_url: https://clic.epfl.ch/association#{{slug}}
       singleton: false
-      sort: null
+      sort: 1
       sort_field: null
       translations: null
       unarchive_value: null
@@ -156,14 +132,14 @@ collections:
       collection: association_poles_translations
       color: null
       display_template: null
-      group: null
+      group: association_poles
       hidden: true
       icon: import_export
       item_duplication_fields: null
       note: null
       preview_url: null
       singleton: false
-      sort: null
+      sort: 1
       sort_field: null
       translations: null
       unarchive_value: null
@@ -176,13 +152,13 @@ collections:
       archive_app_filter: true
       archive_field: null
       archive_value: null
-      collapse: open
+      collapse: closed
       collection: association_public_files
       color: null
       display_template: null
       group: association
       hidden: false
-      icon: null
+      icon: lab_profile
       item_duplication_fields: null
       note: null
       preview_url: null
@@ -235,7 +211,7 @@ collections:
       note: null
       preview_url: null
       singleton: false
-      sort: 2
+      sort: 5
       sort_field: null
       translations: null
       unarchive_value: null
@@ -259,7 +235,7 @@ collections:
       note: null
       preview_url: null
       singleton: false
-      sort: 1
+      sort: 6
       sort_field: null
       translations: null
       unarchive_value: null
@@ -272,18 +248,18 @@ collections:
       archive_app_filter: true
       archive_field: null
       archive_value: null
-      collapse: open
+      collapse: closed
       collection: commission_memberships
       color: null
       display_template: null
       group: commissions
       hidden: false
-      icon: null
+      icon: emoji_people
       item_duplication_fields: null
       note: null
       preview_url: null
       singleton: false
-      sort: 2
+      sort: 1
       sort_field: null
       translations: null
       unarchive_value: null
@@ -307,7 +283,7 @@ collections:
       note: null
       preview_url: null
       singleton: false
-      sort: 1
+      sort: 2
       sort_field: null
       translations: null
       unarchive_value: null
@@ -326,10 +302,10 @@ collections:
       display_template: "{{slug}}"
       group: null
       hidden: false
-      icon: null
+      icon: groups_3
       item_duplication_fields: null
       note: null
-      preview_url: null
+      preview_url: https://clic.epfl.ch/commissions/{{slug}}
       singleton: false
       sort: 2
       sort_field: null
@@ -338,30 +314,6 @@ collections:
       versioning: false
     schema:
       name: commissions
-  - collection: commissions_members
-    meta:
-      accountability: all
-      archive_app_filter: true
-      archive_field: null
-      archive_value: null
-      collapse: open
-      collection: commissions_members
-      color: null
-      display_template: null
-      group: commissions
-      hidden: true
-      icon: import_export
-      item_duplication_fields: null
-      note: null
-      preview_url: null
-      singleton: false
-      sort: 1
-      sort_field: null
-      translations: null
-      unarchive_value: null
-      versioning: false
-    schema:
-      name: commissions_members
   - collection: commissions_social_links
     meta:
       accountability: all
@@ -372,14 +324,14 @@ collections:
       collection: commissions_social_links
       color: null
       display_template: null
-      group: null
+      group: commissions
       hidden: true
       icon: import_export
       item_duplication_fields: null
       note: null
       preview_url: null
       singleton: false
-      sort: 3
+      sort: 2
       sort_field: null
       translations: null
       unarchive_value: null
@@ -396,14 +348,14 @@ collections:
       collection: commissions_translations
       color: null
       display_template: null
-      group: null
+      group: commissions
       hidden: true
       icon: import_export
       item_duplication_fields: null
       note: null
       preview_url: null
       singleton: false
-      sort: 4
+      sort: 3
       sort_field: null
       translations: null
       unarchive_value: null
@@ -422,12 +374,12 @@ collections:
       display_template: "{{code}}"
       group: null
       hidden: false
-      icon: null
+      icon: language
       item_duplication_fields: null
       note: null
       preview_url: null
       singleton: false
-      sort: 5
+      sort: 3
       sort_field: null
       translations: null
       unarchive_value: null
@@ -446,12 +398,12 @@ collections:
       display_template: "{{name}}\_{{surname}}"
       group: null
       hidden: false
-      icon: null
+      icon: frame_person
       item_duplication_fields: null
       note: null
       preview_url: null
       singleton: false
-      sort: 6
+      sort: 4
       sort_field: null
       translations: null
       unarchive_value: null
@@ -464,18 +416,18 @@ collections:
       archive_app_filter: true
       archive_field: status
       archive_value: archived
-      collapse: open
+      collapse: closed
       collection: news
       color: null
       display_template: "{{slug}}"
       group: null
       hidden: false
-      icon: null
+      icon: breaking_news_alt_1
       item_duplication_fields: null
       note: null
-      preview_url: null
+      preview_url: https://clic.epfl.ch/news/{{slug}}
       singleton: false
-      sort: 7
+      sort: 5
       sort_field: sort
       translations: null
       unarchive_value: draft
@@ -492,14 +444,14 @@ collections:
       collection: news_commissions
       color: null
       display_template: null
-      group: null
+      group: news
       hidden: true
       icon: import_export
       item_duplication_fields: null
       note: null
       preview_url: null
       singleton: false
-      sort: 8
+      sort: 2
       sort_field: null
       translations: null
       unarchive_value: null
@@ -516,14 +468,14 @@ collections:
       collection: news_partners
       color: null
       display_template: null
-      group: null
+      group: news
       hidden: true
       icon: import_export
       item_duplication_fields: null
       note: null
       preview_url: null
       singleton: false
-      sort: 9
+      sort: 1
       sort_field: null
       translations: null
       unarchive_value: null
@@ -540,14 +492,14 @@ collections:
       collection: news_translations
       color: null
       display_template: null
-      group: null
+      group: news
       hidden: true
       icon: import_export
       item_duplication_fields: null
       note: null
       preview_url: null
       singleton: false
-      sort: 10
+      sort: 3
       sort_field: null
       translations: null
       unarchive_value: null
@@ -564,14 +516,14 @@ collections:
       collection: partner_category
       color: null
       display_template: null
-      group: null
+      group: partners
       hidden: false
-      icon: null
+      icon: new_releases
       item_duplication_fields: null
       note: null
       preview_url: null
       singleton: false
-      sort: 11
+      sort: 1
       sort_field: null
       translations: null
       unarchive_value: null
@@ -588,14 +540,14 @@ collections:
       collection: partner_category_translations
       color: null
       display_template: null
-      group: null
+      group: partner_category
       hidden: true
       icon: import_export
       item_duplication_fields: null
       note: null
       preview_url: null
       singleton: false
-      sort: 12
+      sort: 1
       sort_field: null
       translations: null
       unarchive_value: null
@@ -614,12 +566,12 @@ collections:
       display_template: "{{name}}"
       group: null
       hidden: false
-      icon: null
+      icon: partner_exchange
       item_duplication_fields: null
       note: null
       preview_url: null
       singleton: false
-      sort: 13
+      sort: 6
       sort_field: null
       translations: null
       unarchive_value: draft
@@ -638,12 +590,12 @@ collections:
       display_template: "{{account_name}} -\_{{media_name}}"
       group: null
       hidden: false
-      icon: null
+      icon: stream_apps
       item_duplication_fields: null
       note: null
       preview_url: null
       singleton: false
-      sort: 14
+      sort: 7
       sort_field: null
       translations: null
       unarchive_value: null
@@ -740,7 +692,8 @@ fields:
       hidden: false
       interface: input
       note: null
-      options: null
+      options:
+        iconLeft: mail
       readonly: false
       required: true
       sort: 4
@@ -778,7 +731,8 @@ fields:
       hidden: false
       interface: input
       note: null
-      options: null
+      options:
+        iconLeft: phone_enabled
       readonly: false
       required: true
       sort: 5
@@ -894,12 +848,37 @@ fields:
       hidden: false
       interface: translations
       note: null
-      options: null
+      options:
+        languageDirectionField: code
+        languageField: name
       readonly: false
       required: false
       sort: 3
       special:
         - translations
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+  - collection: association
+    field: partners
+    type: alias
+    meta:
+      collection: association
+      conditions: null
+      display: null
+      display_options: null
+      field: partners
+      group: null
+      hidden: false
+      interface: list-m2m
+      note: null
+      options: {}
+      readonly: false
+      required: false
+      sort: 10
+      special:
+        - m2m
       translations: null
       validation: null
       validation_message: null
@@ -928,28 +907,45 @@ fields:
       validation_message: null
       width: full
   - collection: association
-    field: partners
-    type: alias
+    field: public_files
+    type: integer
     meta:
       collection: association
       conditions: null
       display: null
       display_options: null
-      field: partners
+      field: public_files
       group: null
       hidden: false
-      interface: list-m2m
+      interface: select-dropdown-m2o
       note: null
-      options: {}
+      options:
+        template: "{{icon.$thumbnail}}{{link}}"
       readonly: false
       required: false
-      sort: 10
+      sort: 9
       special:
-        - m2m
+        - m2o
       translations: null
       validation: null
       validation_message: null
       width: full
+    schema:
+      name: public_files
+      table: association
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: association_public_files
+      foreign_key_column: id
   - collection: association_memberships
     field: id
     type: integer
@@ -1046,10 +1042,16 @@ fields:
         choices:
           - text: Committee
             value: committee
+            color: "#3399FF"
+            icon: groups
           - text: Team
             value: team
+            color: "#FFA439"
+            icon: partner_exchange
           - text: Member
             value: member
+            color: "#A2B5CD"
+            icon: card_membership
       readonly: false
       required: true
       sort: 3
@@ -1115,7 +1117,7 @@ fields:
         enableCreate: false
         template: "{{slug}}"
       readonly: false
-      required: true
+      required: false
       sort: 4
       special:
         - m2o
@@ -1405,158 +1407,6 @@ fields:
       has_auto_increment: false
       foreign_key_table: partners
       foreign_key_column: id
-  - collection: association_pole_translations
-    field: id
-    type: integer
-    meta:
-      collection: association_pole_translations
-      conditions: null
-      display: null
-      display_options: null
-      field: id
-      group: null
-      hidden: true
-      interface: null
-      note: null
-      options: null
-      readonly: false
-      required: false
-      sort: 1
-      special: null
-      translations: null
-      validation: null
-      validation_message: null
-      width: full
-    schema:
-      name: id
-      table: association_pole_translations
-      data_type: integer
-      default_value: nextval('association_pole_translations_id_seq'::regclass)
-      max_length: null
-      numeric_precision: 32
-      numeric_scale: 0
-      is_nullable: false
-      is_unique: true
-      is_primary_key: true
-      is_generated: false
-      generation_expression: null
-      has_auto_increment: true
-      foreign_key_table: null
-      foreign_key_column: null
-  - collection: association_pole_translations
-    field: languages_code
-    type: string
-    meta:
-      collection: association_pole_translations
-      conditions: null
-      display: null
-      display_options: null
-      field: languages_code
-      group: null
-      hidden: true
-      interface: null
-      note: null
-      options: null
-      readonly: false
-      required: false
-      sort: 3
-      special: null
-      translations: null
-      validation: null
-      validation_message: null
-      width: full
-    schema:
-      name: languages_code
-      table: association_pole_translations
-      data_type: character varying
-      default_value: null
-      max_length: 255
-      numeric_precision: null
-      numeric_scale: null
-      is_nullable: true
-      is_unique: false
-      is_primary_key: false
-      is_generated: false
-      generation_expression: null
-      has_auto_increment: false
-      foreign_key_table: languages
-      foreign_key_column: code
-  - collection: association_pole_translations
-    field: description
-    type: text
-    meta:
-      collection: association_pole_translations
-      conditions: null
-      display: null
-      display_options: null
-      field: description
-      group: null
-      hidden: false
-      interface: input-multiline
-      note: null
-      options: null
-      readonly: false
-      required: false
-      sort: 5
-      special: null
-      translations: null
-      validation: null
-      validation_message: null
-      width: full
-    schema:
-      name: description
-      table: association_pole_translations
-      data_type: text
-      default_value: null
-      max_length: null
-      numeric_precision: null
-      numeric_scale: null
-      is_nullable: true
-      is_unique: false
-      is_primary_key: false
-      is_generated: false
-      generation_expression: null
-      has_auto_increment: false
-      foreign_key_table: null
-      foreign_key_column: null
-  - collection: association_pole_translations
-    field: name
-    type: string
-    meta:
-      collection: association_pole_translations
-      conditions: null
-      display: null
-      display_options: null
-      field: name
-      group: null
-      hidden: false
-      interface: input
-      note: null
-      options: null
-      readonly: false
-      required: false
-      sort: 4
-      special: null
-      translations: null
-      validation: null
-      validation_message: null
-      width: full
-    schema:
-      name: name
-      table: association_pole_translations
-      data_type: character varying
-      default_value: null
-      max_length: 255
-      numeric_precision: null
-      numeric_scale: null
-      is_nullable: true
-      is_unique: false
-      is_primary_key: false
-      is_generated: false
-      generation_expression: null
-      has_auto_increment: false
-      foreign_key_table: null
-      foreign_key_column: null
   - collection: association_poles
     field: id
     type: integer
@@ -1596,6 +1446,29 @@ fields:
       foreign_key_table: null
       foreign_key_column: null
   - collection: association_poles
+    field: translations
+    type: alias
+    meta:
+      collection: association_poles
+      conditions: null
+      display: null
+      display_options: null
+      field: translations
+      group: null
+      hidden: false
+      interface: translations
+      note: null
+      options: null
+      readonly: false
+      required: true
+      sort: 4
+      special:
+        - translations
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+  - collection: association_poles
     field: slug
     type: string
     meta:
@@ -1608,7 +1481,8 @@ fields:
       hidden: false
       interface: input
       note: null
-      options: null
+      options:
+        iconLeft: fingerprint
       readonly: false
       required: false
       sort: 2
@@ -1634,29 +1508,6 @@ fields:
       foreign_key_table: null
       foreign_key_column: null
   - collection: association_poles
-    field: translations
-    type: alias
-    meta:
-      collection: association_poles
-      conditions: null
-      display: null
-      display_options: null
-      field: translations
-      group: null
-      hidden: false
-      interface: translations
-      note: null
-      options: null
-      readonly: false
-      required: false
-      sort: 3
-      special:
-        - translations
-      translations: null
-      validation: null
-      validation_message: null
-      width: full
-  - collection: association_poles
     field: mail
     type: string
     meta:
@@ -1669,10 +1520,11 @@ fields:
       hidden: false
       interface: input
       note: null
-      options: null
+      options:
+        iconLeft: mail
       readonly: false
       required: false
-      sort: 4
+      sort: 3
       special: null
       translations: null
       validation: null
@@ -1935,10 +1787,11 @@ fields:
       hidden: false
       interface: input
       note: null
-      options: null
+      options:
+        iconLeft: link
       readonly: false
       required: true
-      sort: 2
+      sort: 3
       special: null
       translations: null
       validation: null
@@ -1961,30 +1814,6 @@ fields:
       foreign_key_table: null
       foreign_key_column: null
   - collection: association_public_files
-    field: translations
-    type: alias
-    meta:
-      collection: association_public_files
-      conditions: null
-      display: null
-      display_options: null
-      field: translations
-      group: null
-      hidden: false
-      interface: translations
-      note: null
-      options:
-        defaultOpenSplitView: true
-      readonly: false
-      required: true
-      sort: 3
-      special:
-        - translations
-      translations: null
-      validation: null
-      validation_message: null
-      width: full
-  - collection: association_public_files
     field: icon
     type: uuid
     meta:
@@ -1997,7 +1826,8 @@ fields:
       hidden: false
       interface: file-image
       note: null
-      options: null
+      options:
+        folder: 82caf9c9-995b-404f-ba7e-76f704a6dd3e
       readonly: false
       required: false
       sort: 4
@@ -2023,6 +1853,32 @@ fields:
       has_auto_increment: false
       foreign_key_table: directus_files
       foreign_key_column: id
+  - collection: association_public_files
+    field: translations
+    type: alias
+    meta:
+      collection: association_public_files
+      conditions: null
+      display: null
+      display_options: null
+      field: translations
+      group: null
+      hidden: false
+      interface: translations
+      note: null
+      options:
+        defaultOpenSplitView: true
+        languageDirectionField: code
+        languageField: name
+      readonly: false
+      required: false
+      sort: 5
+      special:
+        - translations
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
   - collection: association_public_files_translations
     field: id
     type: integer
@@ -2150,7 +2006,8 @@ fields:
       hidden: false
       interface: input
       note: null
-      options: null
+      options:
+        iconLeft: file_copy
       readonly: false
       required: true
       sort: 4
@@ -2641,10 +2498,17 @@ fields:
         choices:
           - text: Committee
             value: committee
+            icon: groups
+            color: "#3399FF"
           - text: Team
             value: team
+            icon: partner_exchange
+            color: "#FFA439"
           - text: Member
             value: member
+            icon: card_membership
+            color: "#2ECDA7"
+        icon: grade
       readonly: false
       required: true
       sort: 4
@@ -2872,7 +2736,8 @@ fields:
       hidden: false
       interface: input
       note: null
-      options: null
+      options:
+        iconLeft: mail
       readonly: false
       required: true
       sort: 2
@@ -2910,7 +2775,8 @@ fields:
       hidden: false
       interface: input
       note: null
-      options: null
+      options:
+        iconLeft: fingerprint
       readonly: false
       required: true
       sort: 3
@@ -2948,7 +2814,8 @@ fields:
       hidden: false
       interface: translations
       note: null
-      options: null
+      options:
+        defaultOpenSplitView: true
       readonly: false
       required: true
       sort: 5
@@ -2971,7 +2838,8 @@ fields:
       hidden: false
       interface: file-image
       note: null
-      options: null
+      options:
+        folder: 07d9aa98-227f-4d9a-916f-e19f30cda26a
       readonly: false
       required: false
       sort: 6
@@ -3081,120 +2949,6 @@ fields:
       validation: null
       validation_message: null
       width: full
-  - collection: commissions_members
-    field: id
-    type: integer
-    meta:
-      collection: commissions_members
-      conditions: null
-      display: null
-      display_options: null
-      field: id
-      group: null
-      hidden: true
-      interface: null
-      note: null
-      options: null
-      readonly: false
-      required: false
-      sort: 1
-      special: null
-      translations: null
-      validation: null
-      validation_message: null
-      width: full
-    schema:
-      name: id
-      table: commissions_members
-      data_type: integer
-      default_value: nextval('commissions_members_id_seq'::regclass)
-      max_length: null
-      numeric_precision: 32
-      numeric_scale: 0
-      is_nullable: false
-      is_unique: true
-      is_primary_key: true
-      is_generated: false
-      generation_expression: null
-      has_auto_increment: true
-      foreign_key_table: null
-      foreign_key_column: null
-  - collection: commissions_members
-    field: commissions_id
-    type: integer
-    meta:
-      collection: commissions_members
-      conditions: null
-      display: null
-      display_options: null
-      field: commissions_id
-      group: null
-      hidden: true
-      interface: null
-      note: null
-      options: null
-      readonly: false
-      required: false
-      sort: 2
-      special: null
-      translations: null
-      validation: null
-      validation_message: null
-      width: full
-    schema:
-      name: commissions_id
-      table: commissions_members
-      data_type: integer
-      default_value: null
-      max_length: null
-      numeric_precision: 32
-      numeric_scale: 0
-      is_nullable: true
-      is_unique: false
-      is_primary_key: false
-      is_generated: false
-      generation_expression: null
-      has_auto_increment: false
-      foreign_key_table: commissions
-      foreign_key_column: id
-  - collection: commissions_members
-    field: members_id
-    type: integer
-    meta:
-      collection: commissions_members
-      conditions: null
-      display: null
-      display_options: null
-      field: members_id
-      group: null
-      hidden: true
-      interface: null
-      note: null
-      options: null
-      readonly: false
-      required: false
-      sort: 3
-      special: null
-      translations: null
-      validation: null
-      validation_message: null
-      width: full
-    schema:
-      name: members_id
-      table: commissions_members
-      data_type: integer
-      default_value: null
-      max_length: null
-      numeric_precision: 32
-      numeric_scale: 0
-      is_nullable: true
-      is_unique: false
-      is_primary_key: false
-      is_generated: false
-      generation_expression: null
-      has_auto_increment: false
-      foreign_key_table: members
-      foreign_key_column: id
   - collection: commissions_social_links
     field: id
     type: integer
@@ -3512,7 +3266,8 @@ fields:
       hidden: false
       interface: file-image
       note: null
-      options: null
+      options:
+        folder: 07d9aa98-227f-4d9a-916f-e19f30cda26a
       readonly: false
       required: false
       sort: 7
@@ -3551,7 +3306,8 @@ fields:
       hidden: false
       interface: input
       note: null
-      options: null
+      options:
+        iconLeft: language
       readonly: false
       required: false
       sort: 2
@@ -3741,7 +3497,8 @@ fields:
       hidden: false
       interface: input
       note: null
-      options: null
+      options:
+        iconLeft: mail
       readonly: false
       required: false
       sort: 4
@@ -3779,7 +3536,8 @@ fields:
       hidden: false
       interface: input
       note: null
-      options: null
+      options:
+        iconLeft: credit_card
       readonly: false
       required: false
       sort: 5
@@ -3817,7 +3575,8 @@ fields:
       hidden: false
       interface: input
       note: null
-      options: null
+      options:
+        iconLeft: link
       readonly: false
       required: false
       sort: 7
@@ -3855,7 +3614,8 @@ fields:
       hidden: false
       interface: file-image
       note: null
-      options: null
+      options:
+        folder: 9dcbb848-a25a-4e75-af0a-abbd1c4555ea
       readonly: false
       required: false
       sort: 6
@@ -3892,8 +3652,8 @@ fields:
       field: poll_count
       group: null
       hidden: false
-      interface: null
-      note: null
+      interface: input
+      note: Poll Count used by RoboCLIC.
       options: null
       readonly: true
       required: true
@@ -3911,7 +3671,7 @@ fields:
       max_length: null
       numeric_precision: 32
       numeric_scale: 0
-      is_nullable: false
+      is_nullable: true
       is_unique: false
       is_primary_key: false
       is_generated: false
@@ -3955,6 +3715,113 @@ fields:
       is_generated: false
       generation_expression: null
       has_auto_increment: true
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: news
+    field: status
+    type: string
+    meta:
+      collection: news
+      conditions: null
+      display: labels
+      display_options:
+        choices:
+          - text: $t:published
+            value: published
+            color: var(--theme--primary)
+            foreground: var(--theme--primary)
+            background: var(--theme--primary-background)
+          - text: $t:draft
+            value: draft
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            background: var(--theme--background-normal)
+          - text: $t:archived
+            value: archived
+            color: var(--theme--warning)
+            foreground: var(--theme--warning)
+            background: var(--theme--warning-background)
+        showAsDot: true
+      field: status
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - text: $t:published
+            value: published
+            color: var(--theme--primary)
+            icon: task_alt
+          - text: $t:draft
+            value: draft
+            color: var(--theme--foreground)
+            icon: draft_orders
+          - text: $t:archived
+            value: archived
+            color: var(--theme--warning)
+            icon: archive
+        icon: null
+      readonly: false
+      required: false
+      sort: 2
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: status
+      table: news
+      data_type: character varying
+      default_value: draft
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: news
+    field: sort
+    type: integer
+    meta:
+      collection: news
+      conditions: null
+      display: null
+      display_options: null
+      field: sort
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      sort: 8
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: sort
+      table: news
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
       foreign_key_table: null
       foreign_key_column: null
   - collection: news
@@ -4078,109 +3945,6 @@ fields:
       foreign_key_table: null
       foreign_key_column: null
   - collection: news
-    field: status
-    type: string
-    meta:
-      collection: news
-      conditions: null
-      display: labels
-      display_options:
-        choices:
-          - text: $t:published
-            value: published
-            color: var(--theme--primary)
-            foreground: var(--theme--primary)
-            background: var(--theme--primary-background)
-          - text: $t:draft
-            value: draft
-            color: var(--theme--foreground)
-            foreground: var(--theme--foreground)
-            background: var(--theme--background-normal)
-          - text: $t:archived
-            value: archived
-            color: var(--theme--warning)
-            foreground: var(--theme--warning)
-            background: var(--theme--warning-background)
-        showAsDot: true
-      field: status
-      group: null
-      hidden: false
-      interface: select-dropdown
-      note: null
-      options:
-        choices:
-          - text: $t:published
-            value: published
-            color: var(--theme--primary)
-          - text: $t:draft
-            value: draft
-            color: var(--theme--foreground)
-          - text: $t:archived
-            value: archived
-            color: var(--theme--warning)
-      readonly: false
-      required: false
-      sort: 2
-      special: null
-      translations: null
-      validation: null
-      validation_message: null
-      width: half
-    schema:
-      name: status
-      table: news
-      data_type: character varying
-      default_value: draft
-      max_length: 255
-      numeric_precision: null
-      numeric_scale: null
-      is_nullable: false
-      is_unique: false
-      is_primary_key: false
-      is_generated: false
-      generation_expression: null
-      has_auto_increment: false
-      foreign_key_table: null
-      foreign_key_column: null
-  - collection: news
-    field: sort
-    type: integer
-    meta:
-      collection: news
-      conditions: null
-      display: null
-      display_options: null
-      field: sort
-      group: null
-      hidden: true
-      interface: input
-      note: null
-      options: null
-      readonly: false
-      required: false
-      sort: 8
-      special: null
-      translations: null
-      validation: null
-      validation_message: null
-      width: full
-    schema:
-      name: sort
-      table: news
-      data_type: integer
-      default_value: null
-      max_length: null
-      numeric_precision: 32
-      numeric_scale: 0
-      is_nullable: true
-      is_unique: false
-      is_primary_key: false
-      is_generated: false
-      generation_expression: null
-      has_auto_increment: false
-      foreign_key_table: null
-      foreign_key_column: null
-  - collection: news
     field: translations
     type: alias
     meta:
@@ -4244,7 +4008,8 @@ fields:
       hidden: false
       interface: input
       note: null
-      options: null
+      options:
+        iconLeft: fingerprint
       readonly: false
       required: true
       sort: 3
@@ -4306,7 +4071,8 @@ fields:
       hidden: false
       interface: input
       note: null
-      options: null
+      options:
+        iconLeft: media_link
       readonly: false
       required: false
       sort: 12
@@ -4801,7 +4567,7 @@ fields:
       interface: file-image
       note: null
       options:
-        folder: fef15ab0-523c-48ac-a20d-e10abfb5a98e
+        folder: 8890baa5-447e-45a3-a573-95c76830e876
       readonly: false
       required: false
       sort: 7
@@ -4877,8 +4643,9 @@ fields:
       group: null
       hidden: false
       interface: input
-      note: null
-      options: null
+      note: 0 is the highest category (e.g. premium)
+      options:
+        iconLeft: workspace_premium
       readonly: false
       required: true
       sort: 2
@@ -4916,7 +4683,8 @@ fields:
       hidden: false
       interface: translations
       note: null
-      options: null
+      options:
+        defaultOpenSplitView: true
       readonly: false
       required: true
       sort: 3
@@ -5052,7 +4820,7 @@ fields:
       group: null
       hidden: false
       interface: input
-      note: null
+      note: Pluralized name of the category
       options: null
       readonly: false
       required: true
@@ -5167,7 +4935,8 @@ fields:
       hidden: false
       interface: file-image
       note: null
-      options: null
+      options:
+        folder: 24a99ee1-4eee-48e1-9960-d51b5a105016
       readonly: false
       required: false
       sort: 5
@@ -5206,7 +4975,8 @@ fields:
       hidden: false
       interface: input
       note: null
-      options: null
+      options:
+        iconLeft: link
       readonly: false
       required: true
       sort: 4
@@ -5352,7 +5122,7 @@ fields:
     meta:
       collection: partners
       conditions: null
-      display: null
+      display: related-values
       display_options: null
       field: category
       group: null
@@ -5361,7 +5131,7 @@ fields:
       note: null
       options:
         enableCreate: false
-        template: "{{translations.name}}"
+        template: "{{rank}}"
       readonly: false
       required: true
       sort: 10
@@ -5438,7 +5208,8 @@ fields:
       hidden: false
       interface: input
       note: null
-      options: null
+      options:
+        iconLeft: link
       readonly: false
       required: true
       sort: 4
@@ -5476,7 +5247,8 @@ fields:
       hidden: false
       interface: file-image
       note: null
-      options: null
+      options:
+        folder: 82caf9c9-995b-404f-ba7e-76f704a6dd3e
       readonly: false
       required: false
       sort: 5
@@ -5515,7 +5287,8 @@ fields:
       hidden: false
       interface: input
       note: null
-      options: null
+      options:
+        iconLeft: app_shortcut
       readonly: false
       required: true
       sort: 2
@@ -5598,6 +5371,27 @@ relations:
       foreign_key_table: directus_files
       foreign_key_column: id
       constraint_name: association_logo_foreign
+      on_update: NO ACTION
+      on_delete: SET NULL
+  - collection: association
+    field: public_files
+    related_collection: association_public_files
+    meta:
+      junction_field: null
+      many_collection: association
+      many_field: public_files
+      one_allowed_collections: null
+      one_collection: association_public_files
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: association
+      column: public_files
+      foreign_key_table: association_public_files
+      foreign_key_column: id
+      constraint_name: association_public_files_foreign
       on_update: NO ACTION
       on_delete: SET NULL
   - collection: association_memberships
@@ -5724,27 +5518,6 @@ relations:
       foreign_key_table: association
       foreign_key_column: id
       constraint_name: association_partners_association_id_foreign
-      on_update: NO ACTION
-      on_delete: SET NULL
-  - collection: association_pole_translations
-    field: languages_code
-    related_collection: languages
-    meta:
-      junction_field: association_pole_id
-      many_collection: association_pole_translations
-      many_field: languages_code
-      one_allowed_collections: null
-      one_collection: languages
-      one_collection_field: null
-      one_deselect_action: nullify
-      one_field: null
-      sort_field: null
-    schema:
-      table: association_pole_translations
-      column: languages_code
-      foreign_key_table: languages
-      foreign_key_column: code
-      constraint_name: association_pole_translations_languages_code_foreign
       on_update: NO ACTION
       on_delete: SET NULL
   - collection: association_poles_translations
@@ -6060,48 +5833,6 @@ relations:
       foreign_key_table: directus_files
       foreign_key_column: id
       constraint_name: commissions_logo_foreign
-      on_update: NO ACTION
-      on_delete: SET NULL
-  - collection: commissions_members
-    field: members_id
-    related_collection: members
-    meta:
-      junction_field: commissions_id
-      many_collection: commissions_members
-      many_field: members_id
-      one_allowed_collections: null
-      one_collection: members
-      one_collection_field: null
-      one_deselect_action: nullify
-      one_field: null
-      sort_field: null
-    schema:
-      table: commissions_members
-      column: members_id
-      foreign_key_table: members
-      foreign_key_column: id
-      constraint_name: commissions_members_members_id_foreign
-      on_update: NO ACTION
-      on_delete: SET NULL
-  - collection: commissions_members
-    field: commissions_id
-    related_collection: commissions
-    meta:
-      junction_field: members_id
-      many_collection: commissions_members
-      many_field: commissions_id
-      one_allowed_collections: null
-      one_collection: commissions
-      one_collection_field: null
-      one_deselect_action: nullify
-      one_field: null
-      sort_field: null
-    schema:
-      table: commissions_members
-      column: commissions_id
-      foreign_key_table: commissions
-      foreign_key_column: id
-      constraint_name: commissions_members_commissions_id_foreign
       on_update: NO ACTION
       on_delete: SET NULL
   - collection: commissions_social_links
@@ -6502,7 +6233,7 @@ relations:
       foreign_key_column: id
       constraint_name: partners_category_foreign
       on_update: NO ACTION
-      on_delete: NO ACTION
+      on_delete: SET NULL
   - collection: social_links
     field: logo
     related_collection: directus_files


### PR DESCRIPTION
Add a directus snapshot containing the data model's hierarchy, icons, and so on. Imported from the production instance.