### PR TITLE
feat: add og properties for preview

### DIFF
--- a/app/src/components/TabTitle.tsx
+++ b/app/src/components/TabTitle.tsx
@@ -1,9 +1,27 @@
 import Head from "next/head";
 
-export default function TabTitle(props: { title: string }) {
+export default function TabTitle(props: {
+  title: string;
+  ogTitle?: string;
+  type?: string;
+  image?: string;
+  description?: string;
+}) {
   return (
     <Head>
       <title>{`CLIC | ${props.title}`}</title>
+      <meta property="og:title" content={props.ogTitle || props.title} />
+      <meta property="og:type" content={props.type || "website"} />
+      {typeof props.image === "string" ? (
+        <meta property="og:image" content={props.image} />
+      ) : (
+        <></>
+      )}
+      {typeof props.description === "string" ? (
+        <meta property="og:description" content={props.description} />
+      ) : (
+        <></>
+      )}
     </Head>
   );
 }

--- a/app/src/directus.ts
+++ b/app/src/directus.ts
@@ -1,6 +1,6 @@
 import { TranslationTable, getTranslation } from "./locales";
 import { Association, Commission, SocialLink } from "./types/aliases";
-import { Schema } from "./types/schema";
+import { Schema, components } from "./types/schema";
 import {
   createDirectus,
   readItems,
@@ -139,4 +139,20 @@ export function cleanTranslations<T extends { [key: string]: any }>(
   return async (context) => {
     return rec(await f(context), context.locale);
   };
+}
+
+/**
+ * Computes the full URL to access an image returned by the Directus instance,
+ * or `undefined` if no image is given.
+ * @param image the image object returned by directus
+ * @returns the full URL of the image, if any
+ */
+export function getDirectusImageUrl(
+  image: string | components["schemas"]["Files"] | null | undefined
+): string | undefined {
+  return image
+    ? `${DIRECTUS_URL}/assets/${
+        typeof image === "string" ? image : image.filename_disk
+      }`
+    : undefined;
 }

--- a/app/src/pages/association.tsx
+++ b/app/src/pages/association.tsx
@@ -1,7 +1,7 @@
 import AssociationDescription from "@/components/AssociationDescription";
 import PoleDescription from "@/components/PoleDescription";
 import TabTitle from "@/components/TabTitle";
-import { directus, populateLayoutProps } from "@/directus";
+import { directus, getDirectusImageUrl, populateLayoutProps } from "@/directus";
 import {
   capitalize,
   getTranslation,
@@ -48,7 +48,14 @@ export default function AssociationPage(
 
   return (
     <div className={styles.main}>
-      <TabTitle title={capitalize(tt["association"])} />
+      <TabTitle
+        title={capitalize(tt["association"])}
+        ogTitle={props.association.name || undefined}
+        description={tt["slogan"]}
+        image={getDirectusImageUrl(
+          getTranslation(props.association, router.locale).banner
+        )}
+      />
 
       <div className={styles.center}>
         <AssociationDescription

--- a/app/src/pages/commissions/[slug].tsx
+++ b/app/src/pages/commissions/[slug].tsx
@@ -2,7 +2,12 @@ import DirectusImage from "@/components/DirectusImage";
 import MembersList from "@/components/MembersList";
 import SocialsList from "@/components/SocialsList";
 import TabTitle from "@/components/TabTitle";
-import { LayoutProps, directus, populateLayoutProps } from "@/directus";
+import {
+  LayoutProps,
+  directus,
+  getDirectusImageUrl,
+  populateLayoutProps,
+} from "@/directus";
 import { getTranslation, locale, queryTranslations } from "@/locales";
 import markdownStyle from "@/styles/Markdown.module.scss";
 import styles from "@/styles/Page.module.scss";
@@ -25,7 +30,11 @@ export default function Page(
 
   return (
     <div className={styles.main}>
-      <TabTitle title={props.commission.name || ""} />
+      <TabTitle
+        title={props.commission.name || ""}
+        description={translation.small_description || undefined}
+        image={getDirectusImageUrl(translation.banner)}
+      />
 
       <div className={styles.center}>
         <DirectusImage

--- a/app/src/pages/index.tsx
+++ b/app/src/pages/index.tsx
@@ -10,7 +10,12 @@ import NewsCard from "@/components/NewsCard";
 import PartnersList from "@/components/PartnersList";
 import SocialsList from "@/components/SocialsList";
 import TabTitle from "@/components/TabTitle";
-import { LayoutProps, directus, populateLayoutProps } from "@/directus";
+import {
+  LayoutProps,
+  directus,
+  getDirectusImageUrl,
+  populateLayoutProps,
+} from "@/directus";
 import {
   getTranslation,
   queryTranslations,
@@ -55,7 +60,12 @@ export default function Home(
 
   return (
     <>
-      <TabTitle title={tt["slogan"]} />
+      <TabTitle
+        title={tt["slogan"]}
+        ogTitle={props.association.name || undefined}
+        description={tt["slogan"]}
+        image={getDirectusImageUrl(translation.banner)}
+      />
       <Background className={styles.background} name="background" />
       <div className={styles.divLogo}>
         <DirectusImage

--- a/app/src/pages/news/[slug].tsx
+++ b/app/src/pages/news/[slug].tsx
@@ -1,7 +1,7 @@
 import CommissionCard from "@/components/CommissionCard";
 import DirectusImage from "@/components/DirectusImage";
 import TabTitle from "@/components/TabTitle";
-import { directus, populateLayoutProps } from "@/directus";
+import { directus, getDirectusImageUrl, populateLayoutProps } from "@/directus";
 import {
   capitalize,
   formatDate,
@@ -26,7 +26,11 @@ export default function Page(
 
   return (
     <div className={styles.main}>
-      <TabTitle title={translation.title || ""} />
+      <TabTitle
+        title={translation.title || ""}
+        description={translation.description}
+        image={getDirectusImageUrl(translation.banner)}
+      />
 
       <div className={styles.center}>
         <DirectusImage


### PR DESCRIPTION
Add [OpenGraph](https://ogp.me/) properties to the `TabTitle` components to enable a preview in many social medias (see #54). Currently, the `news` and `commissions` pages have no image nor descriptions, since there currently is no adequate content on Directus, and I didn't feel like adding some solely for this feature.

I did not find a way to accurately test this feature, since it requires to go through a external tool like Telegram, which probably caches the results on its server side, and obviously cannot access the development server on localhost.

Closes #54.