### PR TITLE
fix: use current user UID and GID instead of fixed ones

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,6 +7,7 @@ services:
   # Directus service
   directus:
     image: directus/directus
+    user: ${UID}:${GID}
     container_name: clic-directus
     environment:
       SECRET: secret
@@ -46,6 +47,7 @@ services:
       context: ./app
       # Path to Dockerfile, relative to context
       dockerfile: Dockerfile.dev
+    user: ${UID}:${GID}
     environment:
       NODE_ENV: development
     volumes:


### PR DESCRIPTION
Fixes an error where the app dev container would be unable to access the files because of a UID/GID mismatch between the host user and the container user. This occurs when the host user (and owner of the files) has not a UID/GID of 1000.