### PR TITLE
fix: directus type generation

### DIFF
--- a/src/components/MembersList.tsx
+++ b/src/components/MembersList.tsx
@@ -59,7 +59,7 @@ export default function MembersList(props: {
       )}
       <div className={styles.list}>
         {props.membership.map((m) => (
-          <Card key={(m as any).id} member={m.member} membership={m} />
+          <Card key={m.id} member={m.member} membership={m} />
         ))}
       </div>
     </div>

--- a/src/locales.ts
+++ b/src/locales.ts
@@ -99,6 +99,7 @@ export function getTranslation<
  *
  * /!\ Do not use when `fields` is set to a custom value /!\
  */
-export const queryTranslations = {
-  fields: ["*", { translations: ["*"] }],
-};
+export const queryTranslations: { fields: ("*" | { translations: "*"[] })[] } =
+  {
+    fields: ["*", { translations: ["*"] }],
+  };

--- a/src/pages/association.tsx
+++ b/src/pages/association.tsx
@@ -89,7 +89,7 @@ export const getServerSideProps: GetServerSideProps<{
   return {
     props: {
       association: await directus().request(
-        readSingleton("association", queryTranslations as any)
+        readSingleton("association", queryTranslations)
       ),
       socialLinks: (await directus()
         .request(
@@ -101,21 +101,16 @@ export const getServerSideProps: GetServerSideProps<{
           result.map((s) => s.social_links_id)
         )) as SocialLink[],
       poles: await directus().request<AssociationPole[]>(
-        readItems("association_poles", queryTranslations as any)
+        readItems("association_poles", queryTranslations)
       ),
       committee: (await directus().request(
         readItems("association_memberships", {
           fields: [
             "*",
             { member: ["*"] },
-            //@ts-ignore
             { translations: ["*"] },
             {
-              pole: [
-                "*",
-                //@ts-ignore
-                { translations: ["*"] },
-              ],
+              pole: ["*", { translations: ["*"] }],
             },
           ],
           filter: { level: { _eq: "committee" } },
@@ -123,11 +118,7 @@ export const getServerSideProps: GetServerSideProps<{
       )) as (AssociationMembership & { member: Member })[],
       publicFiles: await directus().request(
         readItems("association_public_files", {
-          fields: [
-            "*",
-            //@ts-ignore
-            { translations: ["*"], icon: ["*"] },
-          ],
+          fields: ["*", { translations: ["*"], icon: ["*"] }],
         })
       ),
     },

--- a/src/pages/commissions.tsx
+++ b/src/pages/commissions.tsx
@@ -57,7 +57,6 @@ export const getServerSideProps: GetServerSideProps<{
             "name",
             "slug",
             "id",
-            //@ts-ignore
             { translations: ["banner", "small_description", "languages_code"] },
           ],
         })

--- a/src/pages/commissions/[slug].tsx
+++ b/src/pages/commissions/[slug].tsx
@@ -76,7 +76,6 @@ export const getServerSideProps: GetServerSideProps<
   }
 
   let commissions = await directus().request(
-    //@ts-ignore
     readItems("commissions", {
       filter: { slug: { _eq: context.params.slug } },
       ...queryTranslations,
@@ -100,12 +99,7 @@ export const getServerSideProps: GetServerSideProps<
 
   let members = (await directus().request(
     readItems("commission_memberships", {
-      fields: [
-        "*",
-        { member: ["*"] },
-        //@ts-ignore
-        { translations: ["*"] },
-      ],
+      fields: ["*", { member: ["*"] }, { translations: ["*"] }],
       filter: {
         level: { _eq: "committee" },
         commission: { _eq: commission.id },
@@ -115,11 +109,7 @@ export const getServerSideProps: GetServerSideProps<
 
   let partners = (await directus().request(
     readItems("partners", {
-      fields: [
-        "*",
-        //@ts-ignore
-        { category: ["*", { translations: ["*"] }] },
-      ],
+      fields: ["*", { category: ["*", { translations: ["*"] }] }],
       filter: { commission: { _eq: commission.id } },
     })
   )) as Partner[];

--- a/src/pages/icbd.tsx
+++ b/src/pages/icbd.tsx
@@ -231,10 +231,14 @@ export const getServerSideProps: GetServerSideProps<{
             "icon",
             "timeslots",
             "color",
-            //@ts-ignore
             { translations: ["*"] },
-            //@ts-ignore
-            "hosts.icbd_speakers_id.*",
+            {
+              hosts: [
+                {
+                  icbd_speakers_id: ["*"],
+                },
+              ],
+            },
           ],
         })
       ),

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -69,7 +69,7 @@ export default function Home(
         <h1 className="light">News</h1>
         <div className={styles.newsList}>
           {props.news.map((n) => (
-            <NewsCard key={(n as any).id} news={n} />
+            <NewsCard key={n.id} news={n} />
           ))}
         </div>
         <Button text={tt["moreNews"]} onClick={() => router.push("/news")} />
@@ -119,7 +119,7 @@ export const getServerSideProps: GetServerSideProps<
   return {
     props: {
       association: await directus().request(
-        readSingleton("association", queryTranslations as any)
+        readSingleton("association", queryTranslations)
       ),
       partners: (await directus()
         .request(
@@ -164,7 +164,6 @@ export const getServerSideProps: GetServerSideProps<
           fields: [
             "*",
             { member: ["*"] },
-            //@ts-ignore
             { translations: ["*"] },
             { pole: ["slug", { translations: ["name", "languages_code"] }] },
           ],

--- a/src/pages/news.tsx
+++ b/src/pages/news.tsx
@@ -30,7 +30,7 @@ export default function NewsComponent(
         </div>
         <div className={newsStyle.list}>
           {props.news.map((n) => (
-            <NewsCard key={(n as any).id} news={n} />
+            <NewsCard key={n.id} news={n} />
           ))}
         </div>
       </div>

--- a/src/pages/news/[slug].tsx
+++ b/src/pages/news/[slug].tsx
@@ -86,7 +86,6 @@ export const getServerSideProps: GetServerSideProps<{
   }
 
   let news = (await directus().request(
-    //@ts-ignore
     readItems("news", {
       ...queryTranslations,
       limit: 1,
@@ -102,7 +101,13 @@ export const getServerSideProps: GetServerSideProps<{
     .request(
       readItems("news_commissions", {
         ...queryTranslations,
-        fields: [{ commissions_id: ["*.*"] }],
+        fields: [
+          {
+            commissions_id: [
+              { partners: ["*"], social_links: ["*"], translations: ["*"] },
+            ],
+          },
+        ],
         filter: { news_id: { _eq: news[0].id } },
       })
     )

--- a/src/pages/save-the-date.tsx
+++ b/src/pages/save-the-date.tsx
@@ -433,7 +433,6 @@ export const getServerSideProps: GetServerSideProps<{
             "text_color",
             "title_color",
             "button_color",
-            //@ts-ignore
             { translations: ["*"] },
             "language_button_target",
           ],

--- a/src/pages/subsonic.tsx
+++ b/src/pages/subsonic.tsx
@@ -109,9 +109,7 @@ export const getServerSideProps: GetServerSideProps<{
   return {
     props: {
       subsonic: await directus().request(
-        // @ts-ignore
         readSingleton("subsonic", {
-          //@ts-ignore
           fields: ["header_image", "logo", "map", { translations: ["*"] }],
         })
       ),
@@ -125,7 +123,6 @@ export const getServerSideProps: GetServerSideProps<{
               {
                 partners_id: [
                   "*",
-                  //@ts-ignore
                   { category: ["*", { translations: ["*"] }] },
                 ],
               },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,5 +24,5 @@
     ]
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "directus/**/*.ts"]
 }


### PR DESCRIPTION
Requires https://github.com/clicepfl/directus-config/pull/47. Removes `@ts-*` directives and `as any` casts that were necessary due to the broken Directus schema.