### PR TITLE
feat: add api route to render OG images as PNG

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,7 @@
   "editor.codeActionsOnSave": {
     "source.organizeImports": "explicit"
   },
-  "editor.defaultFormatter": "prettier.prettier-vscode",
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnPaste": true,
   "editor.formatOnSave": true,
   /*
@@ -69,15 +69,18 @@
     }
   },
   "[jsonc]": {
-    "editor.defaultFormatter": "prettier.prettier-vscode"
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "[json]": {
-    "editor.defaultFormatter": "prettier.prettier-vscode"
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "[ignore]": {
     "editor.defaultFormatter": "foxundermoon.shell-format"
   },
   "[typescriptreact]": {
-    "editor.defaultFormatter": "prettier.prettier-vscode"
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@directus/sdk": "^18.0.0",
+        "@resvg/resvg-js": "^2.6.2",
         "@svgr/webpack": "^8.1.0",
         "@tsparticles/engine": "^3.7.1",
         "@tsparticles/react": "^3.0.0",
@@ -2726,6 +2727,221 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@resvg/resvg-js": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js/-/resvg-js-2.6.2.tgz",
+      "integrity": "sha512-xBaJish5OeGmniDj9cW5PRa/PtmuVU3ziqrbr5xJj901ZDN4TosrVaNZpEiLZAxdfnhAe7uQ7QFWfjPe9d9K2Q==",
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@resvg/resvg-js-android-arm-eabi": "2.6.2",
+        "@resvg/resvg-js-android-arm64": "2.6.2",
+        "@resvg/resvg-js-darwin-arm64": "2.6.2",
+        "@resvg/resvg-js-darwin-x64": "2.6.2",
+        "@resvg/resvg-js-linux-arm-gnueabihf": "2.6.2",
+        "@resvg/resvg-js-linux-arm64-gnu": "2.6.2",
+        "@resvg/resvg-js-linux-arm64-musl": "2.6.2",
+        "@resvg/resvg-js-linux-x64-gnu": "2.6.2",
+        "@resvg/resvg-js-linux-x64-musl": "2.6.2",
+        "@resvg/resvg-js-win32-arm64-msvc": "2.6.2",
+        "@resvg/resvg-js-win32-ia32-msvc": "2.6.2",
+        "@resvg/resvg-js-win32-x64-msvc": "2.6.2"
+      }
+    },
+    "node_modules/@resvg/resvg-js-android-arm-eabi": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm-eabi/-/resvg-js-android-arm-eabi-2.6.2.tgz",
+      "integrity": "sha512-FrJibrAk6v29eabIPgcTUMPXiEz8ssrAk7TXxsiZzww9UTQ1Z5KAbFJs+Z0Ez+VZTYgnE5IQJqBcoSiMebtPHA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-android-arm64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm64/-/resvg-js-android-arm64-2.6.2.tgz",
+      "integrity": "sha512-VcOKezEhm2VqzXpcIJoITuvUS/fcjIw5NA/w3tjzWyzmvoCdd+QXIqy3FBGulWdClvp4g+IfUemigrkLThSjAQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-darwin-arm64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-arm64/-/resvg-js-darwin-arm64-2.6.2.tgz",
+      "integrity": "sha512-nmok2LnAd6nLUKI16aEB9ydMC6Lidiiq2m1nEBDR1LaaP7FGs4AJ90qDraxX+CWlVuRlvNjyYJTNv8qFjtL9+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-darwin-x64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-x64/-/resvg-js-darwin-x64-2.6.2.tgz",
+      "integrity": "sha512-GInyZLjgWDfsVT6+SHxQVRwNzV0AuA1uqGsOAW+0th56J7Nh6bHHKXHBWzUrihxMetcFDmQMAX1tZ1fZDYSRsw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm-gnueabihf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm-gnueabihf/-/resvg-js-linux-arm-gnueabihf-2.6.2.tgz",
+      "integrity": "sha512-YIV3u/R9zJbpqTTNwTZM5/ocWetDKGsro0SWp70eGEM9eV2MerWyBRZnQIgzU3YBnSBQ1RcxRZvY/UxwESfZIw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm64-gnu": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-gnu/-/resvg-js-linux-arm64-gnu-2.6.2.tgz",
+      "integrity": "sha512-zc2BlJSim7YR4FZDQ8OUoJg5holYzdiYMeobb9pJuGDidGL9KZUv7SbiD4E8oZogtYY42UZEap7dqkkYuA91pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm64-musl": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-musl/-/resvg-js-linux-arm64-musl-2.6.2.tgz",
+      "integrity": "sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-x64-gnu": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-gnu/-/resvg-js-linux-x64-gnu-2.6.2.tgz",
+      "integrity": "sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-x64-musl": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-musl/-/resvg-js-linux-x64-musl-2.6.2.tgz",
+      "integrity": "sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-arm64-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-arm64-msvc/-/resvg-js-win32-arm64-msvc-2.6.2.tgz",
+      "integrity": "sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-ia32-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-ia32-msvc/-/resvg-js-win32-ia32-msvc-2.6.2.tgz",
+      "integrity": "sha512-har4aPAlvjnLcil40AC77YDIk6loMawuJwFINEM7n0pZviwMkMvjb2W5ZirsNOZY4aDbo5tLx0wNMREp5Brk+w==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-x64-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-x64-msvc/-/resvg-js-win32-x64-msvc-2.6.2.tgz",
+      "integrity": "sha512-ZXtYhtUr5SSaBrUDq7DiyjOFJqBVL/dOBN7N/qmi/pO0IgiWW/f/ue3nbvu9joWE5aAKDoIzy/CxsY0suwGosQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@rtsao/scc": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@directus/sdk": "^18.0.0",
+    "@resvg/resvg-js": "^2.6.2",
     "@svgr/webpack": "^8.1.0",
     "@tsparticles/engine": "^3.7.1",
     "@tsparticles/react": "^3.0.0",

--- a/src/components/Icbd.tsx
+++ b/src/components/Icbd.tsx
@@ -4,7 +4,7 @@ import IcbdActivityCard from "@/components/IcbdActivityCard";
 import ParticlesComponent from "@/components/Particles";
 import TabTitle from "@/components/TabTitle";
 import { findStartTime, Timetable } from "@/components/Timetable";
-import { getDirectusImageUrl } from "@/directus";
+import { getDirectusOgImageUrl } from "@/directus";
 import { getTranslation, useTranslationTable } from "@/locales";
 import style from "@/styles/ICBDPage.module.scss";
 import pageStyle from "@/styles/Page.module.scss";
@@ -44,7 +44,7 @@ export default function ICBDDisplay({ icbd }: { icbd: ICBD }) {
         }
       `}</style>
 
-      <TabTitle title={"ICBD"} image={getDirectusImageUrl(icbd.logo)} />
+      <TabTitle title={"ICBD"} image={getDirectusOgImageUrl(icbd.logo)} />
 
       <div className={style.header}>
         <div className={style.logo_div}>

--- a/src/directus.ts
+++ b/src/directus.ts
@@ -163,3 +163,18 @@ export function getDirectusImageUrl(
       }`
     : undefined;
 }
+
+/**
+ * Computes the full URL to access an image in a format appropriate for an OG property.
+ * @param image the image object returned by directus
+ * @returns the full URL of the image, if any
+ */
+export function getDirectusOgImageUrl(
+  image: string | components["schemas"]["Files"] | null | undefined
+): string | undefined {
+  return image
+    ? `/api/og-image?id=${
+        typeof image === "string" ? image : image.filename_disk
+      }`
+    : undefined;
+}

--- a/src/pages/api/og-image.ts
+++ b/src/pages/api/og-image.ts
@@ -1,0 +1,51 @@
+import { directus } from "@/directus";
+import { readAssetArrayBuffer, readFile } from "@directus/sdk";
+import { Resvg } from "@resvg/resvg-js";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<any>
+) {
+  console.log(req.url);
+
+  let id = req.query["id"];
+  if (typeof id !== "string") {
+    return new Response("Missing id parameter", { status: 400 });
+  }
+
+  const d = directus();
+  const data = await d.request(readFile(id, { fields: ["type"] }));
+
+  console.info(data);
+
+  if (data.type == "image/svg+xml") {
+    const file = await d.request(readAssetArrayBuffer(id));
+    const svg = new TextDecoder("utf-8").decode(file);
+
+    const resvg = new Resvg(svg, {
+      background: "rgba(238, 235, 230, .9)",
+      fitTo: {
+        mode: "width",
+        value: 1300,
+      },
+    });
+    const pngData = resvg.render();
+    const pngBuffer = pngData.asPng();
+
+    // TODO: maybe cache it in a file to avoid re-rendering? May be not that useful since OG values are usually cached by the client application servers.
+
+    res.status(200).setHeader("content-type", "image/png").send(pngBuffer);
+  } else {
+    const image = await d.request(
+      readAssetArrayBuffer(id, {
+        fit: "contain",
+        width: 1300,
+        height: 630,
+        format: "jpg",
+      })
+    );
+
+    res.send(Buffer.from(image));
+  }
+}

--- a/src/pages/association.tsx
+++ b/src/pages/association.tsx
@@ -1,7 +1,11 @@
 import AssociationDescription from "@/components/AssociationDescription";
 import PoleDescription from "@/components/PoleDescription";
 import TabTitle from "@/components/TabTitle";
-import { directus, getDirectusImageUrl, populateLayoutProps } from "@/directus";
+import {
+  directus,
+  getDirectusOgImageUrl,
+  populateLayoutProps,
+} from "@/directus";
 import {
   capitalize,
   getTranslation,
@@ -52,7 +56,7 @@ export default function AssociationPage(
         title={capitalize(tt["association"])}
         ogTitle={props.association.name || undefined}
         description={tt["slogan"]}
-        image={getDirectusImageUrl(props.association.preview_image)}
+        image={getDirectusOgImageUrl(props.association.preview_image)}
       />
 
       <div className={styles.center}>

--- a/src/pages/commissions.tsx
+++ b/src/pages/commissions.tsx
@@ -2,7 +2,11 @@ import Background from "@/assets/background.svg";
 import Icon from "@/assets/icons/family.svg";
 import CommissionCard from "@/components/CommissionCard";
 import TabTitle from "@/components/TabTitle";
-import { directus, getDirectusImageUrl, populateLayoutProps } from "@/directus";
+import {
+  directus,
+  getDirectusOgImageUrl,
+  populateLayoutProps,
+} from "@/directus";
 import { capitalize, useTranslationTable } from "@/locales";
 import commissionsStyle from "@/styles/CommissionsPage.module.scss";
 import listPageStyle from "@/styles/ListPage.module.scss";
@@ -19,7 +23,7 @@ export default function Commissions(
     <>
       <TabTitle
         title={capitalize(tt["commissions"])}
-        image={getDirectusImageUrl(props.association.preview_image)}
+        image={getDirectusOgImageUrl(props.association.preview_image)}
       />
 
       <Background className={listPageStyle.background} name="background" />

--- a/src/pages/commissions/[slug].tsx
+++ b/src/pages/commissions/[slug].tsx
@@ -6,7 +6,7 @@ import TabTitle from "@/components/TabTitle";
 import {
   LayoutProps,
   directus,
-  getDirectusImageUrl,
+  getDirectusOgImageUrl,
   populateLayoutProps,
 } from "@/directus";
 import { getTranslation, locale, queryTranslations } from "@/locales";
@@ -35,7 +35,7 @@ export default function Page(
       <TabTitle
         title={props.commission.name || ""}
         description={translation.small_description || undefined}
-        image={getDirectusImageUrl(translation.banner)}
+        image={getDirectusOgImageUrl(translation.banner)}
       />
 
       <div className={styles.center}>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -13,7 +13,7 @@ import TabTitle from "@/components/TabTitle";
 import {
   LayoutProps,
   directus,
-  getDirectusImageUrl,
+  getDirectusOgImageUrl,
   populateLayoutProps,
 } from "@/directus";
 import {
@@ -48,7 +48,7 @@ export default function Home(
         title={tt["slogan"]}
         ogTitle={props.association.name || undefined}
         description={tt["slogan"]}
-        image={getDirectusImageUrl(props.association.preview_image)}
+        image={getDirectusOgImageUrl(props.association.preview_image)}
       />
       <Background className={styles.background} name="background" />
       <div className={styles.divLogo}>

--- a/src/pages/news.tsx
+++ b/src/pages/news.tsx
@@ -2,7 +2,11 @@ import Background from "@/assets/background.svg";
 import Icon from "@/assets/icons/news.svg";
 import NewsCard from "@/components/NewsCard";
 import TabTitle from "@/components/TabTitle";
-import { directus, getDirectusImageUrl, populateLayoutProps } from "@/directus";
+import {
+  directus,
+  getDirectusOgImageUrl,
+  populateLayoutProps,
+} from "@/directus";
 import { capitalize, useTranslationTable } from "@/locales";
 import listPageStyle from "@/styles/ListPage.module.scss";
 import newsStyle from "@/styles/NewsPage.module.scss";
@@ -19,7 +23,7 @@ export default function NewsComponent(
     <>
       <TabTitle
         title={capitalize(tt["news"])}
-        image={getDirectusImageUrl(props.association.preview_image)}
+        image={getDirectusOgImageUrl(props.association.preview_image)}
       />
 
       <Background className={listPageStyle.background} name="background" />

--- a/src/pages/news/[slug].tsx
+++ b/src/pages/news/[slug].tsx
@@ -1,7 +1,11 @@
 import CommissionCard from "@/components/CommissionCard";
 import DirectusImage from "@/components/DirectusImage";
 import TabTitle from "@/components/TabTitle";
-import { directus, getDirectusImageUrl, populateLayoutProps } from "@/directus";
+import {
+  directus,
+  getDirectusOgImageUrl,
+  populateLayoutProps,
+} from "@/directus";
 import {
   capitalize,
   formatDate,
@@ -29,7 +33,7 @@ export default function Page(
       <TabTitle
         title={translation.title || ""}
         description={translation.description}
-        image={getDirectusImageUrl(translation.banner)}
+        image={getDirectusOgImageUrl(translation.banner)}
       />
 
       <div className={styles.center}>

--- a/src/pages/subsonic.tsx
+++ b/src/pages/subsonic.tsx
@@ -2,7 +2,11 @@ import Card from "@/components/Card";
 import DirectusImage from "@/components/DirectusImage";
 import PartnersList from "@/components/PartnersList";
 import TabTitle from "@/components/TabTitle";
-import { directus, getDirectusImageUrl, populateLayoutProps } from "@/directus";
+import {
+  directus,
+  getDirectusOgImageUrl,
+  populateLayoutProps,
+} from "@/directus";
 import { getTranslation, useTranslationTable } from "@/locales";
 import style from "@/styles/SubsonicPage.module.scss";
 import { Artist, Partner, Subsonic } from "@/types/aliases";
@@ -28,7 +32,7 @@ export default function SubsonicPage(
 
       <TabTitle
         title={"Subsonic"}
-        image={getDirectusImageUrl(props.subsonic.logo)}
+        image={getDirectusOgImageUrl(props.subsonic.logo)}
       />
 
       <div className={style.header}>


### PR DESCRIPTION
Adds an API route `/api/og-image?<id>` taking the ID of a directus image and returning the image in a format appropriate for OG properties. In particular, this means that SVGs are rendered into PNG with a width of 1300px. This api can be generated with the `getDirectusOgImageUrl` function and is passed in the `TabTitle` components.

Minor changes:
- Updates the formatter in `.vscode/settings.json` as `prettier.prettier-vscode` was deprecated in favor of `esbenp.prettier-vscode`.