### PR TITLE
feat: use multistage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,36 +4,25 @@ WORKDIR /app
 COPY package*.json .
 ARG NODE_ENV=production
 ENV NODE_ENV=${NODE_ENV}
-
 RUN npm config set fetch-retry-maxtimeout 600000 -g && npm ci
-
 
 # Stage 2: build
 FROM node:25-alpine AS builder
 WORKDIR /app
-
 COPY --from=deps /app/node_modules ./node_modules
-COPY src ./src
-COPY public ./public
 COPY . .
-
 ENV DIRECTUS_URL=https://clic.epfl.ch/directus
 ENV NEXT_PUBLIC_DIRECTUS_URL=https://clic.epfl.ch/directus
-
-RUN apk update
-RUN npm run build
+RUN apk update && npm run build
 
 # Stage 3: run
 FROM node:25-alpine
 WORKDIR /app
-
 # switch to unprivileged user from node base image
 RUN chown -R node .
 USER node
-
 COPY --from=builder /app/.next ./.next
 COPY --from=builder /app/public ./public
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/package.json ./
-
 CMD [ "npm", "start" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,39 @@
-FROM node:18-alpine
-
-RUN apk update
+# Stage 1: install dependencies
+FROM node:18-alpine AS deps
+WORKDIR /app
+COPY package*.json .
 ARG NODE_ENV=production
 ENV NODE_ENV=${NODE_ENV}
+
+RUN npm config set fetch-retry-maxtimeout 600000 -g && npm ci
+
+
+# Stage 2: build
+FROM node:18-alpine AS builder
+WORKDIR /app
+
+COPY --from=deps /app/node_modules ./node_modules
+COPY src ./src
+COPY public ./public
+COPY . .
 
 ENV DIRECTUS_URL=https://clic.epfl.ch/directus
 ENV NEXT_PUBLIC_DIRECTUS_URL=https://clic.epfl.ch/directus
 
-WORKDIR /app
-COPY package.json package-lock.json ./
-RUN npm config set fetch-retry-maxtimeout 600000 -g && npm ci
-
-COPY . .
+RUN apk update
 RUN npm run build
+
+# Stage 3: run
+FROM node:18-alpine
+WORKDIR /app
 
 # switch to unprivileged user from node base image
 RUN chown -R node .
 USER node
+
+COPY --from=builder /app/.next ./.next
+COPY --from=builder /app/public ./public
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/package.json ./
 
 CMD [ "npm", "start" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: install dependencies
-FROM node:18-alpine AS deps
+FROM node:25-alpine AS deps
 WORKDIR /app
 COPY package*.json .
 ARG NODE_ENV=production
@@ -9,7 +9,7 @@ RUN npm config set fetch-retry-maxtimeout 600000 -g && npm ci
 
 
 # Stage 2: build
-FROM node:18-alpine AS builder
+FROM node:25-alpine AS builder
 WORKDIR /app
 
 COPY --from=deps /app/node_modules ./node_modules
@@ -24,7 +24,7 @@ RUN apk update
 RUN npm run build
 
 # Stage 3: run
-FROM node:18-alpine
+FROM node:25-alpine
 WORKDIR /app
 
 # switch to unprivileged user from node base image


### PR DESCRIPTION
Adapt the Dockerfile to use multistage build, reducing image size from 1.85Gb to 750Mb.

Adapted from: https://johnnymetz.com/posts/dockerize-nextjs-app/

Closes #36 